### PR TITLE
Make fonts bad again

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,27 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>shame.dev</title>
-    <!-- Google fonts -->
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css?family=Montserrat:400,600,900"
-      rel="stylesheet"
-    />
-    <!-- Local fonts -->
-    <link
-      rel="preload"
-      as="font"
-      type="font/woff2"
-      href="./roboto-mono-v6-latin-italic.woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      as="font"
-      type="font/woff2"
-      href="./roboto-mono-v6-latin-regular.woff2"
-      crossorigin
-    />
   </head>
   <body>
     <noscript>This site only works with JavaScript enabled. :(</noscript>

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Montserrat:400,600,900');
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
Put Google fonts call back in CSS instead of HTML. Removed preconnect and preload for both web and local fonts.