### PR TITLE
Only load the one function from date-fns instead of the whole esm pkg

### DIFF
--- a/src/components/shamelist/shame.js
+++ b/src/components/shamelist/shame.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from '@reach/router';
-import { formatDistance } from 'date-fns';
+import formatDistance from 'date-fns/formatDistance';
 import Code from './code';
 import Controls from './controls';
 


### PR DESCRIPTION
`import { formatDistance } from 'date-fns';` imports all of date-fns/esm (401.7kb):

![image (5)](https://user-images.githubusercontent.com/4777393/55820125-f6f4c300-5abf-11e9-8213-e36e038e843e.png)

`import formatDistance from 'date-fns/formatDistance';` only imports the one function (32.55kb):
![image (6)](https://user-images.githubusercontent.com/4777393/55820104-ed6b5b00-5abf-11e9-9fee-cbe64d7ae5fc.png)
